### PR TITLE
support for extra initialization options

### DIFF
--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -48,7 +48,7 @@
     if (this.mainmarker) {return this.mainmarker; }
     var gicon, title;
     if (this.markers.length > 1) {
-      gicon = new $googlemaps.MarkerImage('http://thydzik.com/thydzikGoogleMap/markerlink.php?text=' + this.markers.length + '&color=EF9D3F');
+      gicon = new $googlemaps.MarkerImage('http://chart.googleapis.com/chart?chst=d_map_pin_letter&chld=' + this.markers.length + '%7cff776b%7c000000');
       title = 'cluster of ' + this.markers.length + ' markers';
     } else {
       gicon = new $googlemaps.MarkerImage(this.icon);

--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -126,6 +126,8 @@
         mapOptions.mapTypeControlOptions.style = opts.controlsStyle.mapType;
         mapOptions.zoomControlOptions.style = opts.controlsStyle.zoom;
 
+        mapOptions = $.extend(mapOptions, opts.extra);
+
         // Create map and set initial options
         var $gmap = new $googlemaps.Map(this, mapOptions);
 
@@ -873,6 +875,7 @@
       fastClustering: false,
       clusterCount: 10,
       clusterSize: 40 //radius as % of viewport width
-    }
+    },
+    extra: {}
   };
 }(jQuery));


### PR DESCRIPTION
Hi,

I needed something a bit custom and I noticed I had now way of altering all of the options you were passing to the map initializer, so I added an extra option for your plugin that extends the map options with whatever I pass along.

This should be documented on your site and specially note that if you add options that you are currently setting they will be overwritten.

This is what I was trying to accomplish:

``` javascript
$('#map_canvas').gMap({
    address: settings.map_address,
    zoom: 14,
    markers: [
        { 'address' : settings.map_address }
    ],
    extra: {
        mapTypeControlOptions = {
            mapTypeIds: ['map_style', google.maps.MapTypeId.ROADMAP, google.maps.MapTypeId.SATELLITE, google.maps.MapTypeId.HYBRID],
        }       
    }
});
```

which now I can do it. I haven't touched the minified version so let you do that if you want to merge this in.
