### PR TITLE
added in cleanup of markerKeys on removeAllMarkers

### DIFF
--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -666,13 +666,17 @@
          *
          */
     removeAllMarkers: function() {
-      var markers = this.data('gmap').markers, i;
+      var markers = this.data('gmap').markers, markerKeys = this.data('gmap').markerKeys, i;
 
       for (i = 0; i < markers.length; i += 1) {
         markers[i].setMap(null);
         delete markers[i];
       }
       markers.length = 0;
+
+      for (i in markerKeys) {
+        delete markerKeys[i];
+      }
     },
 
     /**


### PR DESCRIPTION
Currently removeAllMarkers doesn't touch the markerKeys hash.  As I
understand it, this would be a bit of a memory link because javascript
can't recycle the google map markers because you still have a reference
to it in markerKeys.  I don't think this is intentional, as there is no
way in the API to actually remove a marker key.  This bit of code cleans
up markerKeys.  I put in a "delete markerKeys[i]" because it matched how
it was being done for the markers array.  I'm not 100% sure it's
necessary in either place.
