### PR TITLE
added removeMarker

### DIFF
--- a/jquery.gmap.js
+++ b/jquery.gmap.js
@@ -679,6 +679,22 @@
       }
     },
 
+    removeMarker: function(marker) {
+      var markers = this.data('gmap').markers, markerKeys = this.data('gmap').markerKeys, i = markers.indexOf(marker);
+
+      if (i !== -1) {
+        markers[i].setMap(null);
+        delete markers[i];
+        markers.splice(i, 1);
+      }
+
+      for (i in markerKeys) {
+        if (markerKeys[i] === marker) {
+          delete markerKeys[i];
+        }
+      }
+    },
+
     /**
          * get marker by key, if set previously
          * @param key


### PR DESCRIPTION
Currently, the only way to remove a marker in gmap is to remove all the
markers.  This can be a bit of a drawback when you've got something like
an interactive map where users can add and remove markers at will.  So I
added a removeMarker which you can pass the google maps Marker object
and it will remove the marker and markerKey (if it exists).
